### PR TITLE
Make SimpleDateFormat more safty to set the locale as `Locale.ENGLISH`

### DIFF
--- a/ch09-risk/src/main/scala/com/cloudera/datascience/risk/RunRisk.scala
+++ b/ch09-risk/src/main/scala/com/cloudera/datascience/risk/RunRisk.scala
@@ -8,6 +8,7 @@ package com.cloudera.datascience.risk
 
 import java.io.File
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
@@ -231,7 +232,7 @@ object RunRisk {
   }
 
   def readInvestingDotComHistory(file: File): Array[(DateTime, Double)] = {
-    val format = new SimpleDateFormat("MMM d, yyyy")
+    val format = new SimpleDateFormat("MMM d, yyyy", Locale.ENGLISH)
     val lines = Source.fromFile(file).getLines().toSeq
     lines.map(line => {
       val cols = line.split('\t')


### PR DESCRIPTION
SimpleDateFormat's `MMM` depends on a setting of locale. To parse such a `Oct` string as a month, the locale should be set as English. So I think we should set the locale with `Locale.ENGLISH`.

I guess the default locale of Japanese people, including me,  is `Locale.JAPANESE`. If so, they can't run this code.

```
new SimpleDateFormat("MMM d, yyyy")
```