### PR TITLE
Unpersist RDDs when no longer needed in Ch 8 code

### DIFF
--- a/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
+++ b/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
@@ -58,6 +58,7 @@ object RunGeoTime extends Serializable {
     }
 
     taxiGood.values.map(hours).countByValue().toList.sorted.foreach(println)
+    taxiParsed.unpersist()
 
     val taxiClean = taxiGood.filter {
       case (lic, trip) => {
@@ -97,10 +98,10 @@ object RunGeoTime extends Serializable {
     }.cache()
 
     taxiDone.values.map(borough).countByValue().foreach(println)
+    taxiGood.unpersist()
 
     def secondaryKeyFunc(trip: Trip) = trip.pickupTime.getMillis
     val sessions = groupByKeyAndSortValues(taxiDone, secondaryKeyFunc, split, 30)
-    sessions.cache()
 
     def boroughDuration(t1: Trip, t2: Trip): (Option[String], Duration) = {
       val b = borough(t1)
@@ -116,6 +117,7 @@ object RunGeoTime extends Serializable {
       }).cache()
 
     boroughDurations.values.map(_.getStandardHours).countByValue().toList.sorted.foreach(println)
+    taxiDone.unpersist()
 
     boroughDurations.filter {
       case (b, d) => d.getMillis >= 0
@@ -124,6 +126,8 @@ object RunGeoTime extends Serializable {
       s.merge(d.getStandardSeconds)
     }).
     reduceByKey((a, b) => a.merge(b)).collect().foreach(println)
+
+    boroughDurations.unpersist()
   }
 
   def point(longitude: String, latitude: String): Point = {


### PR DESCRIPTION
CC @sryza A customer ran into memory problems running this code, and I think the memory pressure can be lessened by unpersisting RDDs that are no longer actively used. It might even be fine to not bother caching anything in this example, but, this change should only unpersist things that aren't used further, or, were never used more than once to start.