### PR TITLE
Clone non-thread-safe formatter to avoid errors in executores with multiple cores

### DIFF
--- a/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
+++ b/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
@@ -137,8 +137,10 @@ object RunGeoTime extends Serializable {
   def parse(line: String): (String, Trip) = {
     val fields = line.split(',')
     val license = fields(1)
-    val pickupTime = new DateTime(formatter.parse(fields(5)))
-    val dropoffTime = new DateTime(formatter.parse(fields(6)))
+    // Not thread-safe:
+    val formatterCopy = formatter.clone().asInstanceOf[SimpleDateFormat]
+    val pickupTime = new DateTime(formatterCopy.parse(fields(5)))
+    val dropoffTime = new DateTime(formatterCopy.parse(fields(6)))
     val pickupLoc = point(fields(10), fields(11))
     val dropoffLoc = point(fields(12), fields(13))
 


### PR DESCRIPTION
@sryza here's a fun one. In the Ch 08 code there's a shared static `SimpleDateFormatter`. These are not thread-safe, though. When you run this code through executors with 2 or more cores, you'll eventually mis-parse dates or throw a bunch of exceptions. However the exceptions are caught and collected in an RDD, which is collected to the driver. This can end up being half the data set and crashes everything.

The simple and efficient fix is to clone the object. This let me run reliably with 12+ cores and generated only about the desired 3,400 bad records.