### PR TITLE
Avoid loading a whole partition in memory in groupSorted

### DIFF
--- a/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
+++ b/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
@@ -192,12 +192,12 @@ object RunGeoTime extends Serializable {
         curLic = lic
         curTrips.clear()
         curTrips += trip
-        Some(result)
+        if (result._2.isEmpty) None else Some(result)
       } else {
         curTrips += trip
         None
       }
-    }
+    } ++ Iterator((curLic, List(curTrips:_*)))
   }
 }
 

--- a/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
+++ b/ch08-geotime/src/main/scala/com/cloudera/datascience/geotime/RunGeoTime.scala
@@ -184,23 +184,20 @@ object RunGeoTime extends Serializable {
   def groupSorted[K, V, S](
       it: Iterator[((K, S), V)],
       splitFunc: (V, V) => Boolean): Iterator[(K, List[V])] = {
-    val res = List[(K, ArrayBuffer[V])]()
-    it.foldLeft(res)((list, next) => list match {
-      case Nil => {
-        val ((lic, _), trip) = next
-        List((lic, ArrayBuffer(trip)))
+    var curLic: K = null.asInstanceOf[K]
+    val curTrips = ArrayBuffer[V]()
+    it.flatMap { case ((lic, _), trip) =>
+      if (!lic.equals(curLic) || splitFunc(curTrips.last, trip)) {
+        val result = (curLic, List(curTrips:_*))
+        curLic = lic
+        curTrips.clear()
+        curTrips += trip
+        Some(result)
+      } else {
+        curTrips += trip
+        None
       }
-      case cur :: rest => {
-        val (curLic, trips) = cur
-        val ((lic, _), trip) = next
-        if (!lic.equals(curLic) || splitFunc(trips.last, trip)) {
-          (lic, ArrayBuffer(trip)) :: list
-        } else {
-          trips.append(trip)
-          list
-        }
-      }
-    }).map { case (lic, buf) => (lic, buf.toList) }.iterator
+    }
   }
 }
 


### PR DESCRIPTION
@sryza another one for you. I found that this final stage easily runs out of memory on bottou. If I'm reading it right, it actually builds a whole partition's worth of results in memory. I don't think that's necessary. It's possible to build up the (license, trips) pairs on the fly. Check my work though, does it make sense? I don't have a good way of verifying the result, but, it certainly uses less memory.