### PR TITLE
choose close value to analyze

### DIFF
--- a/ch09-risk/src/main/scala/com/cloudera/datascience/risk/RunRisk.scala
+++ b/ch09-risk/src/main/scala/com/cloudera/datascience/risk/RunRisk.scala
@@ -65,7 +65,7 @@ class RunRisk(private val spark: SparkSession) {
     lines.tail.map { line =>
       val cols = line.split(',')
       val date = LocalDate.parse(cols(0), formatter)
-      val value = cols(1).toDouble
+      val value = cols(4).toDouble
       (date, value)
     }.reverse.toArray
   }


### PR DESCRIPTION
Some open values from Google have '-' entries, which causes an Exception. Choosing close values looks all right.