### PR TITLE
Opened Spark session should be closed on exit

### DIFF
--- a/ch05-kmeans/src/main/R/kmeans-visualization.R
+++ b/ch05-kmeans/src/main/R/kmeans-visualization.R
@@ -65,3 +65,4 @@ colors = sapply(clusters, function(c) palette[c])
 plot3d(projected_data, col = colors, size = 10)
 
 unpersist(numeric_only)
+sparkR.session.stop()


### PR DESCRIPTION
Hello,

In case of resources optimization, I thought we should close sparkR session as soon as we have finished working with data.
I've added a stop() call to the end of the code snippet, what do you think about it? Is it necessary? 

What happens when we shut down RStudio, does the session automatically wiped?