### PR TITLE
refactoring the longform function

### DIFF
--- a/ch02-intro/src/main/scala/com/cloudera/datascience/intro/RunIntro.scala
+++ b/ch02-intro/src/main/scala/com/cloudera/datascience/intro/RunIntro.scala
@@ -112,10 +112,7 @@ object RunIntro extends Serializable {
     val columns = desc.schema.map(_.name)
     desc.flatMap(row => {
       val metric = row.getAs[String](columns.head)
-      val valueColumns = columns match {
-        case x :: tail => tail
-      }
-      valueColumns.map(columnName => (metric, columnName, row.getAs[String](columnName).toDouble))
+      columns.tail.map(columnName => (metric, columnName, row.getAs[String](columnName).toDouble))
     } ).toDF("metric", "field", "value")
   }
 }

--- a/ch02-intro/src/main/scala/com/cloudera/datascience/intro/RunIntro.scala
+++ b/ch02-intro/src/main/scala/com/cloudera/datascience/intro/RunIntro.scala
@@ -107,7 +107,7 @@ object RunIntro extends Serializable {
       agg(first("value"))
   }
 
-  def longForm(desc:DataFrame): DataFrame = {
+  def longForm(desc: DataFrame): DataFrame = {
     import desc.sparkSession.implicits._ // For toDF RDD -> DataFrame conversion
     val columns = desc.schema.map(_.name)
     desc.flatMap(row => {


### PR DESCRIPTION
Hey what do you think of this? I am working through the book now and even with the description I found it tough to follow the transformation that was happening. I reimplemented it myself as an exercise to understand the transformation better.

I've not seen the `(1 until row.size).map( ... )` style expression before, so in mine I used pattern matching on the list, which I see a lot in other codebases.

There's no difference in performance and I extracted the output from the result and it's identical. I've attached both. To reproduce these documents just run with `spark-submit` and then find and replace on `[0-9]+-[0-9]+-[0-9]+.*\n`. [Original Output](https://gist.github.com/reynoldsm88/89db28dd4fc330c0331e1d6869eb16de), [Updated Output](https://gist.github.com/reynoldsm88/bc66f5b07ac8621135222016060a6bce)
