### PR TITLE
Maven profile 2.4 references Scala 2.12 which leads to errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,8 +419,8 @@
       <id>spark-2.4</id>
       <properties>
         <spark.version>2.4.3</spark.version>
-        <scala.minor.version>2.12</scala.minor.version>
-        <scala.complete.version>${scala.minor.version}.8</scala.complete.version>
+        <scala.minor.version>2.11</scala.minor.version>
+        <scala.complete.version>${scala.minor.version}.12</scala.complete.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Running the ch03-recommender example via a maven built project using the spark-2.4 profile (`mvn -Pspark-2.4 package`), the following error will result when launched using spark-submit:

Exception in thread "main" java.lang.NoSuchMethodError: scala.Predef$.refArrayOps([Ljava/lang/Object;)[Ljava/lang/Object;

[Spark downloads page](https://spark.apache.org/downloads.html) says "Note that, Spark is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12."

Reverting to Scala 2.11 fixes the issue. Not sure this is the correct fix as I'm not very experienced in Spark yet. Works for me.